### PR TITLE
small readme and comment touchups

### DIFF
--- a/env-example
+++ b/env-example
@@ -1,6 +1,6 @@
 AWS_ACCESS_KEY_ID=CHANGE_ME
 AWS_SECRET_ACCESS_KEY=CHANGE_ME
-AWS_REGION=us-west-2
+AWS_DEFAULT_REGION=us-west-2
 AWS_ROLE_ARN=arn:aws:iam::418214828013:role/DevelopersRole
 SPEECH_TO_TEXT_S3_BUCKET=sul-speech-to-text-dev-your-username
 SPEECH_TO_TEXT_TODO_SQS_QUEUE=sul-speech-to-text-todo-dev-your-username

--- a/speech_to_text.py
+++ b/speech_to_text.py
@@ -45,7 +45,7 @@ def main(daemon=True):
 
 def get_job():
     """
-    Fetch the next job that is queued for processing. If no job is found in 90
+    Fetch the next job that is queued for processing. If no job is found in WaitTimeSeconds
     seconds None will be returned.
     """
     queue = get_todo_queue()


### PR DESCRIPTION
follow-ons from review and testing of #9:
* tweak the readme section on job structure to match the current code, to explain more explicitly the relationship between job fields and worker file processing, and to remove vestiges (i think?) of an earlier iteration of #9 where the job info was passed to the worker via actual file on S3 bucket, instead of as payload of an SQS message.
* tweak a code comment that seemed to drift from implementation, and add a `region_name` param to a to a `boto3.resource` instance creation, since i got errors in local testing without that.