### PR TITLE
[HOLD] only need vtt and txt files in output

### DIFF
--- a/speech_to_text.py
+++ b/speech_to_text.py
@@ -151,7 +151,7 @@ def upload_results(job: dict) -> dict:
     output_dir = get_output_dir(job)
     for path in output_dir.iterdir():
         # ignore non output files
-        if path.suffix not in [".vtt", ".srt", ".json", ".txt", ".tsv"]:
+        if path.suffix not in [".vtt", ".txt"]:
             continue
 
         key = f"{job['id']}/output/{path.name}"

--- a/tests/test_speech_to_text.py
+++ b/tests/test_speech_to_text.py
@@ -78,10 +78,10 @@ def test_speech_to_text(bucket, queues):
     job = json.loads(job_file["Body"].read().decode("utf-8"))
     assert len(job["output"]) == 5
     assert f"{job_id}/output/en.vtt" in job["output"]
-    assert f"{job_id}/output/en.srt" in job["output"]
     assert f"{job_id}/output/en.txt" in job["output"]
-    assert f"{job_id}/output/en.tsv" in job["output"]
-    assert f"{job_id}/output/en.json" in job["output"]
+    assert f"{job_id}/output/en.srt" not in job["output"]
+    assert f"{job_id}/output/en.tsv" not in job["output"]
+    assert f"{job_id}/output/en.json" not in job["output"]
 
     # did the max_line_width option take effect?
     assert (


### PR DESCRIPTION
Part of #41 - we only need the txt and vtt files in the output

Question: is there some Whisper config that will stop the others from even being produced?