### PR TITLE
Check media and log attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 whisper_models
 *.log
+.python-version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3
+ffprobe3
 openai-whisper
 python-dotenv
 pytest

--- a/tests/test_inspect_media.py
+++ b/tests/test_inspect_media.py
@@ -1,0 +1,23 @@
+from speech_to_text import inspect_media, SpeechToTextException
+
+import pytest
+
+
+def test_duration():
+    result = inspect_media("tests/data/en.wav")
+    assert result["duration"] == 3.220000
+
+
+def test_format():
+    result = inspect_media("tests/data/en.wav")
+    assert result["format"] == "wav"
+
+
+def test_size():
+    result = inspect_media("tests/data/en.wav")
+    assert result["size"] == 618318
+
+
+def test_invalid_media():
+    with pytest.raises(SpeechToTextException):
+        inspect_media("README.md")


### PR DESCRIPTION
This commit uses ffprobe, which comes with ffmpeg (a Whisper requirement), to check that the file being transcribed is an audio or video format that ffmpeg understands. The format, duration and size of the file is logged to make it a bit easier to analyze the speech-to-text logs.

If an invalid file is supplied to the service it will raise an exception indicating that the format was invalid. This ultimately gets caught and logged so that it doesn't terminate the service.

Closes #48
Closes #31
