### PR TITLE
Set word_timestamps on transcription

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:22.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3.11 \
+    python3.11-dev \
     python3-distutils \
     python3-pip \
     ffmpeg

--- a/speech_to_text.py
+++ b/speech_to_text.py
@@ -123,7 +123,10 @@ def run_whisper(job: dict) -> dict:
         media_file = media["name"]
 
         whisper_options = {**options, **media.get("options", {})}
-        writer_options = get_writer_options(whisper_options)
+
+        writer_options = whisper_options.get("writer", {})
+        if len(writer_options) > 0:
+            whisper_options["word_timestamps"] = True
 
         # remove model and writer from options that are passed to whisper
         whisper_options.pop("model", None)
@@ -201,24 +204,6 @@ def finish_job(job: dict) -> dict:
     queue.send_message(MessageBody=json.dumps(job))
 
     return job
-
-
-def get_writer_options(job: dict) -> dict:
-    word_options = [
-        "highlight_words",
-        "max_line_count",
-        "max_line_width",
-        "max_words_per_line",
-    ]
-
-    opts = {option: job.get("writer", {}).get(option) for option in word_options}
-
-    # ensure word_timestamps is set if any of the word options are
-    # the timestamps are used by the writer
-    if len(opts) > 0:
-        opts["word_timestamps"] = True
-
-    return opts
 
 
 def get_s3() -> S3ServiceResource:

--- a/tests/test_speech_to_text.py
+++ b/tests/test_speech_to_text.py
@@ -87,6 +87,7 @@ def test_speech_to_text(bucket, queues):
 
     # did the max_line_width option take effect?
     assert job["log"]["runs"][0]["media"] == f"{job_id}/en.wav"
+    assert job["log"]["runs"][0]["transcribe"]["word_timestamps"] is True
     assert job["log"]["runs"][0]["write"]["max_line_width"] == 42
 
     # is there a message in the "done" queue?


### PR DESCRIPTION
`word_timestamps` is currently being set on the writer options instead of the transcribe options. Without `word_timestamps` turned on the writer options have no effect.

You can compare a transcript created by our integration test before and after this change:

before: https://stacks-stage.stanford.edu/file/druid:jq613qs8296/video_1.vtt
after: https://stacks-stage.stanford.edu/file/druid:jm706vb3065/video_1.vtt

Notice how the line lengths in the second are much shorter?

However I did notice that the improved VTT still displays all jammed together? https://sul-purl-stage.stanford.edu/jm706vb3065 Maybe that's an issue with sul_embed when trying to use a Whisper generated VTT?

Also the `python3.11-dev` package appears to be necessary in the Docker container, because without it we see errors about missing Python.h when running with `word_timestamps` turned on.

```
/usr/local/lib/python3.11/dist-packages/whisper/timing.py:42: UserWarning: Failed to launch Triton kernels, likely due to missing CUDA toolkit; falling back to a slower median kernel implementation...
  warnings.warn(
/tmp/tmp4hckhwc0/main.c:5:10: fatal error: Python.h: No such file or directory
    5 | #include <Python.h>
      |          ^~~~~~~~~~
compilation terminated.
```

Closes #35
