### PR TITLE
cast a wider net for .env files to ignore (e.g. .env.qa)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .venv
-.env
+.env*
 __pycache__/
 whisper_models
 *.log


### PR DESCRIPTION
i have a `.env.qa` locally, and this keeps that file from showing up in the `Untracked files` listing.