### PR TITLE
Remove ffprobe3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 boto3
 boto3-stubs[s3,sqs,sts]
-ffprobe3
 honeybadger
 moto[s3,sqs,sts]
 mypy


### PR DESCRIPTION
We aren't using this Python library. I accidentally added when testing whether it was needed.
