### PR TITLE
Use a nvidia/cuda base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:22.04
+FROM nvidia/cuda:12.1.0-devel-ubuntu20.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python3.11 \
-    python3.11-dev \
+    python3 \
+    python3-dev \
     python3-distutils \
     python3-pip \
     ffmpeg
@@ -12,9 +12,9 @@ WORKDIR /app
 ADD ./whisper_models whisper_models
 ADD ./requirements.txt requirements.txt
 
-RUN python3.11 -m pip install --upgrade pip
-RUN python3.11 -m pip install -r requirements.txt
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install -r requirements.txt
 
 ADD ./speech_to_text.py speech_to_text.py
 
-ENTRYPOINT ["python3.11", "speech_to_text.py"]
+ENTRYPOINT ["python3", "speech_to_text.py"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This repository contains a Docker configuration for performing serverless speech
 
 ## Build
 
+First a note of caution if you are updating the Docker image. In order to prevent random segmentation faults you will want to make sure that:
+
+1. You are using an [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) base Docker image.
+2. The version of CUDA you are using in the Docker container aligns with the version of CUDA that is installed in the host operating system that is running Docker.
+
 To build the container you will need to first download the pytorch models that Whisper uses. This is about 13GB of data and can take some time! The idea here is to bake the models into Docker image so they don't need to be fetched dynamically every time the container runs (which will add to the runtime). If you know you only need one size model, and want to just include that then edit the `whisper_models/urls.txt` file accordingly before running the `wget` command.
 
 ```shell

--- a/speech_to_text.py
+++ b/speech_to_text.py
@@ -10,7 +10,6 @@ import uuid
 import shutil
 import subprocess
 import traceback
-from honeybadger import honeybadger
 from functools import cache
 from pathlib import Path
 from typing import Optional, Dict
@@ -19,6 +18,7 @@ import boto3
 import dotenv
 import torch
 import whisper
+from honeybadger import honeybadger
 from whisper.utils import get_writer
 from mypy_boto3_s3.service_resource import Bucket, S3ServiceResource
 from mypy_boto3_sqs.service_resource import SQSServiceResource, Queue
@@ -290,7 +290,7 @@ def check_env() -> None:
 
 
 def now() -> str:
-    return datetime.datetime.now(datetime.UTC).isoformat()
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
 def get_output_dir(job) -> Path:


### PR DESCRIPTION
We've been seeing occasional segfaults after the Docker container has processed a sequence of files. This item in stage has 16 files which seems to consistently trigger a segfault, afterwhich the container completely exits without sending an error message of any kind.

https://argo-qa.stanford.edu/view/xx631hs6770 seems to regularly

While searching for information about segfaults in Docker when using pytorch I ran across people recommending the [nvidia/cuda base images](https://hub.docker.com/r/nvidia/cuda) are used when using pytorch in Docker.

I also noticed that the host operating system we are using on EC2 `Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04) 20241004` is configured to use CUDA 12.1 but more recent versions were getting installed into the Docker Container.

```
ubuntu@ip-10-0-0-185:~$ ls -l /usr/local/cuda
lrwxrwxrwx 1 root root 21 Oct  4 07:44 /usr/local/cuda -> /usr/local/cuda-12.1/
```

This commit updates the Docker container to use an older base nvidia/cuda ubuntu base image `nvidia/cuda:12.1.0-devel-ubuntu20.04` to match the version of CUDA and uses the version of python3 that that it comes with (python v3.8.10) instead of trying to add our own.

The good news is that the problematic item https://argo-qa.stanford.edu/view/xx631hs6770 is processed fine with this configuration!

Closes #62
