### PR TITLE
Align CI Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.8]
     steps:
 
       - name: checkout

--- a/speech_to_text.py
+++ b/speech_to_text.py
@@ -10,7 +10,6 @@ import uuid
 import shutil
 import subprocess
 import traceback
-from functools import cache
 from pathlib import Path
 from typing import Optional, Dict
 
@@ -371,7 +370,6 @@ def inspect_media(path) -> dict:
         raise SpeechToTextException(f"Invalid media file {path}")
 
 
-@cache
 def load_whisper_model(model_name) -> whisper.model.Whisper:
     if torch.cuda.is_available():
         device = "cuda"


### PR DESCRIPTION
We are not using Python 3.8 in production to align better witht the version of Python and CUDA libraries that are installed in the host production environment. It's probably best for us to test the version of Python that we are actually using.

Also this PR removes the use of `functools.cache` since it isn't available in python 3.8, and hasn't appeared to be needed anyway.