### PR TITLE
Add Github Action deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,27 @@
+# Build and deploy a Docker image to the production AWS environment
+# when a new release has been created.
+
+name: Deploy to Production
+
+on:
+  release:
+    types:
+      published
+
+jobs:
+  deploy-prod:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Build and push Docker image to production
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PRODUCTION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}
+          AWS_ECR_DOCKER_REPO: ${{ secrets.AWS_ECR_DOCKER_REPO_PRODUCTION }}
+        run: |
+          echo "production deploy not yet enabled"
+          # uncomment this when the keys are avaialable!
+          # ./deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+# Build and deploy a Docker image to development and staging AWS environments
+# when a tagged version is created during weekly dependency updates.
+
+name: Deploy
+
+on:
+  push:
+    tags:
+      - 'rel-*-*-*'
+
+jobs:
+  deploy-stage-qa:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Build and push Docker image to development (qa in SDR)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEVELOPMENT }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
+          AWS_ECR_DOCKER_REPO: ${{ secrets.AWS_ECR_DOCKER_REPO_DEVELOPMENT }}
+        run: ./deploy.sh
+
+      - name: Build and push Docker image to staging
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+          AWS_ECR_DOCKER_REPO: ${{ secrets.AWS_ECR_DOCKER_REPO_STAGING }}
+        run: ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# The following environment variables will need to be set in order to push the
+# new speech-to-text Docker image:
+#
+# - AWS_ACCESS_KEY_ID: the access key for the speech-to-text user
+# - AWS_SECRET_ACCESS_KEY: the secret key for the speech-to-text user
+# - AWS_ECR_DOCKER_REPO: the Elastic Compute Registry URL for the Docker repository
+#
+# The values can be obtained by running `terraform output` in the relevant portion of
+# the Terraform configuration.
+
+# Exit immediately if something doesn't work
+
+set -e
+
+# Download the Whisper large-v3 model, which is what we use by default. Building
+# the image with the model in it already will speed up processing since whisper
+# won't need to pull it dynamically.
+
+wget --timestamping --directory whisper_models https://openaipublic.azureedge.net/main/whisper/models/e5b1a55b89c1367dacf97e3e19bfd829a01529dbfdeefa8caeb59b3f1b81dadb/large-v3.pt 
+
+# Log in to ECR
+
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $AWS_ECR_DOCKER_REPO
+
+# Build the image for Linux (not really needed when running in Github Actions)
+
+docker build -t speech-to-text --platform="linux/amd64" .
+
+# Tag and push the image to ECR
+
+docker tag speech-to-text $AWS_ECR_DOCKER_REPO
+
+docker push $AWS_ECR_DOCKER_REPO

--- a/speech_to_text.py
+++ b/speech_to_text.py
@@ -280,7 +280,7 @@ def load_whisper_model(model_name) -> whisper.model.Whisper:
 def create(media_path: Path):
     """
     Create a job for a given media file by placing the media file in S3 and then
-    creating a batch job which can be picked up ot perform transcription using
+    creating a batch job which can be picked up to perform transcription using
     boilerplate options.
     """
     job_id = str(uuid.uuid4())


### PR DESCRIPTION
With this configuration a Github Action will run when a release tag `release-YYYY-MM-DD` has been created during weekly dependency updates. The action will build the Docker container and deploy it to the development (qa in SDR) and staging AWS environments. This will allow the First Responder for the week to test the latest code using the speech-to-text integration tests.

When the tag has been tested and is ready for production a developer will need to create a release in Github using the release tag. This will cause a build and deploy to the production AWS environment. We may want to think about automated ways for this to happen, but the "serverless" nature of AWS Batch means there really isn't a server for Capistrano (what we use to do other infra deploys) to talk to.

The keys for the different environments need to be set as [Github Action Secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions).

- AWS_ACCESS_KEY_ID_DEVELOPMENT
- AWS_SECRET_ACCESS_KEY_DEVELOPMENT
- AWS_ECR_DOCKER_REPO_DEVELOPMENT
- AWS_ACCESS_KEY_ID_STAGING
- AWS_SECRET_ACCESS_KEY_STAGING
- AWS_ECR_DOCKER_REPO_STAGING
- AWS_ACCESS_KEY_ID_PRODUCTION
- AWS_SECRET_ACCESS_KEY_PRODUCTION
- AWS_ECR_DOCKER_REPO_PRODUCTION

Note: only dlss-ops has permission to see the keys for the speech-to-text user in production. So for now the production deploy is a no-op until we actually do need to run in production. Maybe this could be ticketed as follow on work?

I tested using the [rel-2025-01-29](https://github.com/sul-dlss/speech-to-text/releases/tag/rel-2025-01-29) release tag, which [triggered the deploy Github Action](https://github.com/sul-dlss/speech-to-text/actions/runs/13041232017/job/36383367274), built and pushed the Docker image to the development and staging AWS environments. I confirmed I could see them in the ECR AWS Console and then watched the speech to text integration test pass.

I also created a Github Release for [rel-2025-01-29](https://github.com/sul-dlss/speech-to-text/releases/tag/rel-2025-01-29) which triggered the [deploy-prod Github Action](https://github.com/sul-dlss/speech-to-text/actions/runs/13041669092) which is currently a no-op until we configure the Github repository with the necessary secrets for the speech-to-text user in the production AWS environment.

Closes #46