### PR TITLE
add pytest-cov, add coverage reporting to CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+cov-report = term,html
+omit = tests/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,16 @@ jobs:
       - name: Run type checking
         run: mypy .
 
+      - name: Download code coverage reporter and notify Code Climate of the build
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+
       - name: Run tests
-        run: pytest
+        run: pytest --cov-report=xml
+
+      - name: Notify Code Climate that the build is done
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        run: ./cc-test-reporter after-build --coverage-input-type=coverage.py --exit-code $?

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ whisper_models
 terraform.tfstate
 terraform.tfstate.backup
 variables.tf
+.coverage
+.coverage.*

--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ If you get no result, install with:
 
 `brew install ffmpeg`
 
+### Test coverage reporting
+
+In addition to the terminal display of a summary of the test coverage percentages, you can get a detailed look at which lines are covered or not by opening `htmlcov/index.html` after running the test suite.
+
 ## Continuous Integration
 
 This Github repository is set up with a Github Action that will automatically deployed tagged releases e.g. `rel-2025-01-01` to the DLSS development and staging AWS environments. When a Github release is created it will automatically be deployed to the production AWS environment.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 log_level = INFO
 log_file = test.log
 pythonpath = .
+addopts = --cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ honeybadger
 moto[s3,sqs,sts]
 mypy
 openai-whisper
-python-dotenv
 pytest
+pytest-cov
+python-dotenv
 ruff


### PR DESCRIPTION
If you go to the open source org in https://codeclimate.com/dashboard, and navigate to this project, you can see it's reporting.  but i can't figure out how to add it back as a check in the PR status, even though the webhook is enabled and PR reporting is on in Code Climate for the project.

Coverage does at least report as expected in the terminal, and the HTML report mentioned in the readme works.  Example output:
```
---------- coverage: platform darwin, python 3.12.8-final-0 ----------
Name                Stmts   Miss  Cover
---------------------------------------
speech_to_text.py     197     52    74%
---------------------------------------
TOTAL                 197     52    74%

============================================ 8 passed, 5 warnings in 5.93s =============================================
```