### PR TITLE
align deployment env names for honeybadger with those specified in terraform

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,7 +22,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}
           AWS_ECR_DOCKER_REPO: ${{ secrets.AWS_ECR_DOCKER_REPO_PRODUCTION }}
           HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
-          DEPLOYMENT_ENV: prod
+          DEPLOYMENT_ENV: production
         run: |
           echo "production deploy not yet enabled"
           # uncomment this when the keys are avaialable!

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,5 +31,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
           AWS_ECR_DOCKER_REPO: ${{ secrets.AWS_ECR_DOCKER_REPO_STAGING }}
           HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
-          DEPLOYMENT_ENV: stage
+          DEPLOYMENT_ENV: staging
         run: ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You will want to set these in your environment:
 - AWS_ACCESS_KEY_ID: the `text_to_speech_access_key_id` value
 - AWS_SECRET_ACCESS_KEY: the `text_to_speech_secret_access_key`
 - AWS_ECR_DOCKER_REPO: the `docker_repository` value
-- DEPLOYMENT_ENV: the SDR environment being deployed to (e.g. qa, stage, prod)
+- DEPLOYMENT_ENV: the SDR environment being deployed to (e.g. qa, staging, production)
 - HONEYBADGER_API_KEY: the API key for this project, to support deployment notifications (obtainable from project settings in HB web UI)
 
 Then you can run the deploy:

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@
 # - AWS_ACCESS_KEY_ID: the access key for the speech-to-text user
 # - AWS_SECRET_ACCESS_KEY: the secret key for the speech-to-text user
 # - AWS_ECR_DOCKER_REPO: the Elastic Compute Registry URL for the Docker repository
-# - DEPLOYMENT_ENV: the SDR environment being deployed to (e.g. qa, stage, prod)
+# - DEPLOYMENT_ENV: the SDR environment being deployed to (e.g. qa, staging, production)
 # - HONEYBADGER_API_KEY: the API key for this project, to support deployment notifications (obtainable from project settings in HB web UI)
 #
 # The values can be obtained by running `terraform output` in the relevant portion of


### PR DESCRIPTION
this fixes the names to be the same as the ones specified for reporting in the container env vars (see [related TF PR](https://github.com/sul-dlss/terraform-aws/pull/1213), which uses existing environment names of `staging`, `production`, and `qa`).