### PR TITLE
typo fix in README, pass aws region env var to deploy.sh in github deploy workflows, add aws region env var to deploy script top level comment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,6 +21,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PRODUCTION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}
           AWS_ECR_DOCKER_REPO: ${{ secrets.AWS_ECR_DOCKER_REPO_PRODUCTION }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
           DEPLOYMENT_ENV: production
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEVELOPMENT }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
           AWS_ECR_DOCKER_REPO: ${{ secrets.AWS_ECR_DOCKER_REPO_DEVELOPMENT }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
           DEPLOYMENT_ENV: qa
         run: ./deploy.sh
@@ -30,6 +31,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
           AWS_ECR_DOCKER_REPO: ${{ secrets.AWS_ECR_DOCKER_REPO_STAGING }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
           DEPLOYMENT_ENV: staging
         run: ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ If there was an error during processing the `output` will be an empty list, and 
 
 ## Manually Running a Job
 
-We don't actually interact with the speech-to-text service using the awscli utility at the command line. Instead the speech-to-text service is used by our digital repository, in our case the [common-accessioning](https://github.com/sul-dlss/common-accessioning)) system, which interacts directly with AWS using a Ruby AWS client. If you would like to simulate this yourself you can run the `speech_to_text.py` with the `--create` and `--done` flags.
+We don't actually interact with the speech-to-text service using the awscli utility at the command line. Instead the speech-to-text service is used by our digital repository, in our case the [common-accessioning](https://github.com/sul-dlss/common-accessioning) system, which interacts directly with AWS using a Ruby AWS client. If you would like to simulate this yourself you can run the `speech_to_text.py` with the `--create` and `--done` flags.
 
 First you will need a `.env` file that tells `speech_to_text.py` your AWS credentials and some of the resources that Terraform configured for you.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,7 @@
 # - AWS_ACCESS_KEY_ID: the access key for the speech-to-text user
 # - AWS_SECRET_ACCESS_KEY: the secret key for the speech-to-text user
 # - AWS_ECR_DOCKER_REPO: the Elastic Compute Registry URL for the Docker repository
+# - AWS_DEFAULT_REGION: the AWS region in which the ECR instance lives
 # - DEPLOYMENT_ENV: the SDR environment being deployed to (e.g. qa, staging, production)
 # - HONEYBADGER_API_KEY: the API key for this project, to support deployment notifications (obtainable from project settings in HB web UI)
 #


### PR DESCRIPTION
tiny follow on to #79, noticed the extra paren thing in PR review, then thought of the env var stuff right after i merged