### PR TITLE
Ensure there is no pre-existing virtual environment

### DIFF
--- a/.autoupdate/preupdate
+++ b/.autoupdate/preupdate
@@ -3,7 +3,7 @@
 
 # This script is called by our weekly dependency update job in Jenkins
 
-pip3 install uv > speech-to-text.txt &&
+pip3 install --upgrade uv > speech-to-text.txt && rm -rf .venv &&
     ~/.local/bin/uv lock --upgrade >> speech-to-text.txt
 
 retVal=$?


### PR DESCRIPTION
It's not clear if this will help, but perhaps ensuring there is no previous virtual environment will help when running dependency updates?

I tried `uv lock --upgrade` in my home directory with the same version of uv as Jenkins is using (v0.6.10) and it ran fine. 🤷

Ref #91
